### PR TITLE
update mobile view to no longer scroll unless content overflows

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -129,3 +129,8 @@ body, html {
   padding: 0;
   height: 100%;
 }
+
+#_next, main {
+  height: 100%;
+  overflow: hidden;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ export default function Home() {
 
   
   return (
-    <main className = "flex min-h-screen flex-col items-center justify-center p-24">
+    <main className = "flex h-screen flex-col items-center justify-center p-24">
       
       
       <Quiz />


### PR DESCRIPTION
This pull request includes changes to the styling and layout of the `src/app` directory to ensure consistent height and overflow behavior across different elements.

Styling and layout improvements:

* [`src/app/globals.css`](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R132-R136): Added styles to set the height to 100% and hide overflow for `#_next` and `main` elements.
This is because Next automatically wraps the page in a `div` with the id `_next`, so making that, and then the `main `element take up 100% of the height meant it was taking up the full screen and overflow: hidden prevents scrolling.
* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL10-R10): Modified the `main` element to use `h-screen` instead of `min-h-screen` for consistent full-screen height.

Further improvement might include adjusting padding and font sizes for mobile screens. I saw you using sm: in a few places, but it didn't seem to make any difference